### PR TITLE
Don't apply resize work on iOS7

### DIFF
--- a/keyboard/src/ios/CDVKeyboard.m
+++ b/keyboard/src/ios/CDVKeyboard.m
@@ -148,6 +148,9 @@
     if (ashrinkView == _shrinkView) {
         return;
     }
+    if (IsAtLeastiOSVersion(@"7.0")) {
+        return;
+    }
 
     if (ashrinkView) {
         [nc removeObserver:_shrinkViewKeyboardShowObserver];
@@ -238,6 +241,9 @@
     if (!_shrinkView) {
         return;
     }
+    if (IsAtLeastiOSVersion(@"7.0")) {
+        return;
+    }
     _savedWebViewFrame = self.webView.frame;
 
     CGRect keyboardFrame = [notif.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
@@ -257,6 +263,9 @@
 
 - (void)shrinkViewKeyboardWillHideHelper:(NSNotification*)notif
 {
+    if (IsAtLeastiOSVersion(@"7.0")) {
+        return;
+    }
     self.webView.scrollView.scrollEnabled = YES;
 
     CGRect keyboardFrame = [notif.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];


### PR DESCRIPTION
If there is a fixed position, bottom positioned element on the page, this keyboard plugin causes awkward re-layouts of the element on keyboard pop up -- but only occasionally (I can attach screenshots if you cannot reproduce).

Repro steps:
1. Add to blank app: <input type=text style="position:fixed; bottom: 5px; right: 5px;" value="Hello"></input>
2. 'cordova emulate ios' on ios7 simulator
3. click the input box to open keyboard
4. See input briefly in right position, then migrate to the top of page

It appears there is a race of some kind, since it happens consistently when run in simulator outside of xcode via 'cordova emulate ios', but does not happen when using xcode debugging or when run on device.

While this doesn't seem high priority, as far as I can tell, this code is not doing anything useful on ios7, so can just safely just be no-oped.  WDYT?
