### PR TITLE
Height of status bar added to webview on hide even though it was overlaying the webview

### DIFF
--- a/statusbar/src/ios/CDVStatusBar.m
+++ b/statusbar/src/ios/CDVStatusBar.m
@@ -160,16 +160,14 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
         CGRect frame = self.webView.frame;
 
-        if(!self.statusBarOverlaysWebView){
-            if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
-                frame.origin.y = statusBarFrame.size.width;
-                frame.size.height -= statusBarFrame.size.width;
-            } else {
-                frame.origin.y = statusBarFrame.size.height;
-                frame.size.height -= statusBarFrame.size.height;
-            }
+        if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+            frame.origin.y = statusBarFrame.size.width;
+            frame.size.height -= statusBarFrame.size.width;
+        } else {
+            frame.origin.y = statusBarFrame.size.height;
+            frame.size.height -= statusBarFrame.size.height;
         }
-        
+
         self.webView.frame = frame;
         [self.webView.superview addSubview:_statusBarBackgroundView];
     }
@@ -320,10 +318,12 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
         CGRect frame = self.webView.frame;
         frame.origin.y = 0;
         
-        if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
-            frame.size.height += statusBarFrame.size.width;
-        } else {
-            frame.size.height += statusBarFrame.size.height;
+        if(!self.statusBarOverlaysWebView){
+            if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+                frame.size.height += statusBarFrame.size.width;
+            } else {
+                frame.size.height += statusBarFrame.size.height;
+            }
         }
         
         self.webView.frame = frame;


### PR DESCRIPTION
Added a check to the StatusBar.hide() call such that the size of the status  is only added to the webview if the status bar was not overlaying the webview.
