### PR TITLE
Fix keyboard background with HideFormAccessoryBar

### DIFF
--- a/keyboard/src/ios/CDVKeyboard.m
+++ b/keyboard/src/ios/CDVKeyboard.m
@@ -204,7 +204,12 @@
                 for (UIView* peripheralView in view.subviews) {
                     // hides the backdrop (iOS 7)
                     if ([[peripheralView description] hasPrefix:@"<UIKBInputBackdropView"]) {
-                        [[peripheralView layer] setOpacity:0.0];
+                        // check that this backdrop is for the accessory bar (at the top),
+                        // sparing the backdrop behind the main keyboard
+                        CGRect rect = peripheralView.frame;
+                        if (rect.origin.y == 0) {
+                            [[peripheralView layer] setOpacity:0.0];
+                        }
                     }
 
                     // hides the accessory bar


### PR DESCRIPTION
Fix CB-6219 by preventing the main keyboard from becoming transparent on iOS 7. (This looked particularly bad on iOS 7.1, where a white background would render the Shift key icons invisible.)

Thanks to http://stackoverflow.com/questions/18837551/remove-keyboard-form-toolbar-on-ios7-leaves-a-blur-behind/19042392#comment28210345_19042392
