### PR TITLE
Resize webView to handle orientation change when keyboard will hide

### DIFF
--- a/keyboard/src/ios/CDVKeyboard.m
+++ b/keyboard/src/ios/CDVKeyboard.m
@@ -293,6 +293,9 @@
     keyboardFrame = [self.viewController.view convertRect:keyboardFrame fromView:nil];
 
     CGRect newFrame = _savedWebViewFrame;
+    newFrame.size.width = self.viewController.view.bounds.size.width - _savedWebViewFrame.origin.x;
+    newFrame.size.height = self.viewController.view.bounds.size.height - _savedWebViewFrame.origin.y;
+    
     self.webView.scrollView.contentInset = UIEdgeInsetsMake(0, 0, 0, 0);
     self.webView.frame = newFrame;
 }


### PR DESCRIPTION
The webView does not get properly resized if the orientation changes before the keyboard is dismissed. This issue was introduced by CB-5516. Rather restoring the entire savedWebViewFrame, just use the origin of the savedWebViewFrame to transform the the viewController.view.bounds.
