### PR TITLE
Keyboard: Fix issue with UIPickerViews breaking.

### DIFF
--- a/keyboard/src/ios/CDVKeyboard.m
+++ b/keyboard/src/ios/CDVKeyboard.m
@@ -260,7 +260,10 @@
     if (!_shrinkView) {
         return;
     }
-    _savedWebViewFrame = self.webView.frame;
+
+    if (CGRectIsEmpty(_savedWebViewFrame)) {
+        _savedWebViewFrame = self.webView.frame;
+    }
 
     CGRect keyboardFrame = [notif.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
     keyboardFrame = [self.viewController.view convertRect:keyboardFrame fromView:nil];
@@ -298,6 +301,8 @@
     
     self.webView.scrollView.contentInset = UIEdgeInsetsMake(0, 0, 0, 0);
     self.webView.frame = newFrame;
+
+    _savedWebViewFrame = CGRectNull;
 }
 
 // //////////////////////////////////////////////////


### PR DESCRIPTION
Going from a keyboard to a select dropdown picker triggered the show handler without ever calling the hide handler. Going from a select list to a keyboard triggered show again.
At this point, the UIWebView had been shrunk to the point of having a height of 0.

/cc @shazron
