### PR TITLE
Fix sdcard misspelling

### DIFF
--- a/file-system-roots/android/FileSystemRoots.java
+++ b/file-system-roots/android/FileSystemRoots.java
@@ -123,7 +123,7 @@ public class FileSystemRoots extends CordovaPlugin {
             case PURPOSE_DOCUMENTS:
                 if (sandboxed && installedFilesystems.contains("documents")) {
                     path = "cdvfile://localhost/documents/";
-                } else if (installedFilesystems.contains("scdard")) {
+                } else if (installedFilesystems.contains("sdcard")) {
                     path = "cdvfile://localhost/sdcard/";
                 }
                 break;


### PR DESCRIPTION
``` js
cordova.filesystem.getDirectoryForPurpose('documents', {sandboxed:false}, function(a) { console.log(a.nativeURL) }, function(a) { console.error(a) })
```

**Before:**
-> No path found.

**After:**
-> file:///storage/emulated/0
