### PR TITLE
Update README.md

### DIFF
--- a/local-webserver/README.md
+++ b/local-webserver/README.md
@@ -14,8 +14,7 @@ Check your console log for errors in configuration.
 
     In order to limit access to your app, requests are restricted to localhost and are protected with an auth token.
     This should effectively restrict access to the server to your app.
-    However, since requests are made over http, your app's activity may be visible to others on the name wi-fi network.
-
+    
 This plugin is only compatible with the 3.7.0 release of cordova-ios, or greater.
     
 


### PR DESCRIPTION
Remove inaccurate "Security Caveats" sentence, as discussed on the cordova-dev mailing list. 

For reference from http://en.wikipedia.org/wiki/Localhost#Name_resolution:
"The processing of any packets sent to a loopback address is implemented in the link layer of the TCP/IP stack. Such packets are never delivered to any network interface controller (NIC) or device driver".

Sorry about this @shazron and thanks @devgeeks.
