### PR TITLE
CB-8337: Fix keyboardShrinksView for external keyboards, CB-8339 enable keyboardShrinksView on iOS 7.1+

### DIFF
--- a/keyboard/src/ios/CDVKeyboard.h
+++ b/keyboard/src/ios/CDVKeyboard.h
@@ -21,8 +21,6 @@
 
 @interface CDVKeyboard : CDVPlugin {
     @protected
-    CGRect _savedWebViewFrame;
-    @protected
     BOOL _shrinkView;
     @protected
     BOOL _hideFormAccessoryBar;
@@ -31,7 +29,7 @@
     @protected
     id _hideFormAccessoryBarKeyboardShowObserver, _hideFormAccessoryBarKeyboardHideObserver;
     @protected
-    id _shrinkViewKeyboardShowObserver, _shrinkViewKeyboardHideObserver;
+    id _shrinkViewKeyboardWillChangeFrameObserver;
     @protected
     CGFloat _accessoryBarHeight;
 }

--- a/keyboard/src/ios/CDVKeyboard.m
+++ b/keyboard/src/ios/CDVKeyboard.m
@@ -70,14 +70,12 @@
                                              queue:[NSOperationQueue mainQueue]
                                         usingBlock:^(NSNotification* notification) {
             [weakSelf.commandDelegate evalJs:@"Keyboard.fireOnShow();"];
-            weakSelf.keyboardIsVisible = YES;
         }];
     _keyboardHideObserver = [nc addObserverForName:UIKeyboardDidHideNotification
                                             object:nil
                                              queue:[NSOperationQueue mainQueue]
                                         usingBlock:^(NSNotification* notification) {
             [weakSelf.commandDelegate evalJs:@"Keyboard.fireOnHide();"];
-            weakSelf.keyboardIsVisible = NO;
         }];
 
     _keyboardWillShowObserver = [nc addObserverForName:UIKeyboardWillShowNotification
@@ -85,12 +83,14 @@
                                              queue:[NSOperationQueue mainQueue]
                                         usingBlock:^(NSNotification* notification) {
             [weakSelf.commandDelegate evalJs:@"Keyboard.fireOnShowing();"];
+            weakSelf.keyboardIsVisible = YES;
         }];
     _keyboardWillHideObserver = [nc addObserverForName:UIKeyboardWillHideNotification
                                             object:nil
                                              queue:[NSOperationQueue mainQueue]
                                         usingBlock:^(NSNotification* notification) {
             [weakSelf.commandDelegate evalJs:@"Keyboard.fireOnHiding();"];
+            weakSelf.keyboardIsVisible = NO;
         }];
     
     _shrinkViewKeyboardWillChangeFrameObserver = [nc addObserverForName:UIKeyboardWillChangeFrameNotification
@@ -271,7 +271,7 @@
     CGRect keyboard = [self.viewController.view convertRect: ((NSValue*)notif.userInfo[@"UIKeyboardFrameEndUserInfoKey"]).CGRectValue fromView: nil];
     CGRect keyboardIntersection = CGRectIntersection(screen, keyboard);
 
-    if(CGRectContainsRect(screen, keyboardIntersection) && !CGRectIsEmpty(keyboardIntersection)&& _shrinkView){
+    if(CGRectContainsRect(screen, keyboardIntersection) && !CGRectIsEmpty(keyboardIntersection) && _shrinkView && self.keyboardIsVisible){
         screen.size.height -= MIN(keyboardIntersection.size.height, keyboardIntersection.size.width);
         
         if (_hideFormAccessoryBar){

--- a/keyboard/src/ios/CDVKeyboard.m
+++ b/keyboard/src/ios/CDVKeyboard.m
@@ -101,6 +101,8 @@
                                                              }];
     
     self.webView.scrollView.delegate = self;
+    
+    _accessoryBarHeight = 44;
 }
 
 // //////////////////////////////////////////////////
@@ -269,8 +271,13 @@
     CGRect keyboard = [self.viewController.view convertRect: ((NSValue*)notif.userInfo[@"UIKeyboardFrameEndUserInfoKey"]).CGRectValue fromView: nil];
     CGRect keyboardIntersection = CGRectIntersection(screen, keyboard);
 
-    if(CGRectContainsRect(screen, keyboardIntersection) && _shrinkView){
+    if(CGRectContainsRect(screen, keyboardIntersection) && !CGRectIsEmpty(keyboardIntersection)&& _shrinkView){
         screen.size.height -= MIN(keyboardIntersection.size.height, keyboardIntersection.size.width);
+        
+        if (_hideFormAccessoryBar){
+            screen.size.height += _accessoryBarHeight;
+        }
+        
         self.webView.scrollView.scrollEnabled = !self.disableScrollingInShrinkView;
     }
     

--- a/keyboard/src/ios/CDVKeyboard.m
+++ b/keyboard/src/ios/CDVKeyboard.m
@@ -255,7 +255,10 @@
     
     self.webView.scrollView.scrollEnabled = YES;
     
-    CGRect screen = [self.viewController.view convertRect:[[UIScreen mainScreen] applicationFrame] fromView:nil];
+    CGRect screen = self.webView.frame.origin.y > 0 ?
+    [self.viewController.view convertRect:[[UIScreen mainScreen] applicationFrame] fromView:nil]:
+    [self.viewController.view convertRect:[[UIScreen mainScreen] bounds] fromView:nil];
+
     CGRect keyboard = [self.viewController.view convertRect: ((NSValue*)notif.userInfo[@"UIKeyboardFrameEndUserInfoKey"]).CGRectValue fromView: nil];
     CGRect keyboardIntersection = CGRectIntersection(screen, keyboard);
 
@@ -269,13 +272,7 @@
         self.webView.scrollView.scrollEnabled = !self.disableScrollingInShrinkView;
     }
     
-    __weak CDVKeyboard* weakSelf = self;
-    [UIView animateWithDuration:[notif.userInfo[@"UIKeyboardAnimationDurationUserInfoKey"] doubleValue]
-                          delay:0.0
-                        options:[notif.userInfo[@"UIKeyboardAnimationCurveUserInfoKey"] integerValue] << 16
-                     animations:^{
-                         weakSelf.webView.frame = screen;
-                     }completion:nil];
+    self.webView.frame = screen;
 }
 
 // //////////////////////////////////////////////////

--- a/keyboard/src/ios/CDVKeyboard.m
+++ b/keyboard/src/ios/CDVKeyboard.m
@@ -32,7 +32,7 @@
 
 @implementation CDVKeyboard
 
-@dynamic shrinkView, hideFormAccessoryBar;
+@dynamic hideFormAccessoryBar;
 
 - (id)settingForKey:(NSString*)key
 {
@@ -155,18 +155,6 @@
     }
 
     _hideFormAccessoryBar = ahideFormAccessoryBar;
-}
-
-// //////////////////////////////////////////////////
-
-- (BOOL)shrinkView
-{
-    return _shrinkView;
-}
-
-- (void)setShrinkView:(BOOL)ashrinkView
-{
-    _shrinkView = ashrinkView;
 }
 
 // //////////////////////////////////////////////////


### PR DESCRIPTION
Instead of listening for keyboard show and hide events, the plugin now listens for keyboard frame change events and responds accordingly. This should also fix CB-5711 or any other case where the keyboard frame changes without firing a show or hide event.

This also changes keyboardShrinksView from being a no-op on iOS >= 7.0 to being a no-op on iOS = 7.0 and  fixes the screen being pushed up before being resized (CB-5642.)