### PR TITLE
CB-10953: Return after calling complete

### DIFF
--- a/local-webserver/src/ios/CDVLocalWebServer.m
+++ b/local-webserver/src/ios/CDVLocalWebServer.m
@@ -220,6 +220,7 @@
         NSString *host = [request.headers objectForKey:@"Host"];
         if (host==nil || [host hasPrefix:@"localhost"] == NO ) {
             complete([GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"FORBIDDEN"]);
+            return;
         }
 
         //check if the querystring or the cookie has the token
@@ -228,6 +229,7 @@
         BOOL hasCookie = (cookie && [cookie containsString:authToken]);
         if (!hasToken && !hasCookie) {
             complete([GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"FORBIDDEN"]);
+            return;
         }
 
         processRequestForResponseBlock(request, ^void(GCDWebServerResponse* response){


### PR DESCRIPTION
This fixes a SIGABRT in `GCDWebServerConnection`: calling `complete` twice fails, because we already have a `_responseMessage` for the connection after the first `complete`.
