### PR TITLE
CB-10958: Retain the `src` attribute of the `content` element when it…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # OS X
 .DS_Store
+# NPM
+*/node_modules

--- a/local-webserver/package.json
+++ b/local-webserver/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "cordova-labs-local-webserver",
+  "version": "2.3.1",
+  "description": "Cordova Local Web Server Plugin",
+  "cordova": {
+    "id": "cordova-labs-local-webserver",
+    "platforms": [
+      "ios"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Collaborne/cordova-plugins.git"
+  },
+  "keywords": [
+    "cordova",
+    "local web server",
+    "ecosystem:cordova",
+    "cordova-ios"
+  ],
+  "engines": [
+    {
+      "name": "cordova-ios",
+      "version": ">=4.0.0-dev"
+    }
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Collaborne/cordova-plugins/issues"
+  },
+  "homepage": "https://github.com/Collaborne/cordova-plugins#readme",
+  "dependencies": {
+    "urijs": "^1.17.1"
+  }
+}

--- a/local-webserver/plugin.xml
+++ b/local-webserver/plugin.xml
@@ -86,7 +86,7 @@
         <framework src="libz.dylib" />
 
         <info>
-        Your content tag in config.xml now points to a http://localhost:0 location (randomized port), e.g. &lt;content src="http://localhost:0" /&gt;
+        If your &lt;content&gt; element did not already point to 'http://localhost[:port]', it will now point to a http://localhost:0 location (randomized port), e.g. &lt;content src="http://localhost:0" /&gt;
         WARNING: For localStorage and IndexedDB persistence, you must choose a non-randomized port (between 1 and 49152, to avoid the ephemeral port range 49152 to 65535 on iOS).
     </info>
 

--- a/local-webserver/scripts/after_install.js
+++ b/local-webserver/scripts/after_install.js
@@ -22,9 +22,9 @@
 // This script modifies the project root's config.xml
 // The <content> tag "src" attribute is modified to point to http://localhost:0
 
-var content_src_value = "http://localhost:0";
 var fs = require('fs');
 var path = require('path');
+var URI = require('urijs');
 var old_content_src_value;
 
 module.exports = function(context) {
@@ -37,11 +37,15 @@ module.exports = function(context) {
     var content_tags = etree.findall('./content[@src]');
     if (content_tags.length > 0) {
         old_content_src_value = content_tags[0].get('src');
-        var backup_json = path.join(context.opts.plugin.dir, 'backup.json');
-        var backup_value = { content_src : old_content_src_value };
-        fs.writeFileSync(backup_json, JSON.stringify(backup_value));
+        var content_src = URI.parse(old_content_src_value);
+        if (content_src.hostname !== 'localhost') {
+            var backup_json = path.join(context.opts.plugin.dir, 'backup.json');
+            var backup_value = { content_src : old_content_src_value };
+            fs.writeFileSync(backup_json, JSON.stringify(backup_value));
 
-        content_tags[0].set('src', content_src_value);
+            // XXX: Should we retain the name of the index file here?
+            content_tags[0].set('src', 'http://localhost:0');
+        }
     }
 
     var altcontentsrcTag = etree.findall("./preference[@name='AlternateContentSrc']");


### PR DESCRIPTION
… already points to localhost

---

Note that this does also add a package.json file for the urijs dependency.
