### PR TITLE
CB-11643: return after sending error

### DIFF
--- a/local-webserver/src/ios/CDVLocalWebServer.m
+++ b/local-webserver/src/ios/CDVLocalWebServer.m
@@ -220,6 +220,7 @@
         NSString *host = [request.headers objectForKey:@"Host"];
         if (host==nil || [host hasPrefix:@"localhost"] == NO ) {
             complete([GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"FORBIDDEN"]);
+            return;
         }
 
         //check if the querystring or the cookie has the token
@@ -228,6 +229,7 @@
         BOOL hasCookie = (cookie && [cookie containsString:authToken]);
         if (!hasToken && !hasCookie) {
             complete([GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"FORBIDDEN"]);
+            return;
         }
 
         processRequestForResponseBlock(request, ^void(GCDWebServerResponse* response){


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

After an error is returned, we should return and not process the request. Continuing to process the request can cause a crash.

### What testing has been done on this change?

Tested on a device with the sample app, adding the following code.

```
document.getElementById("deviceready").addEventListener("click", function buttonClick() {
            var fail = function () { console.log("failure"); }
            var photoSuccess = function (uri) {
                var img = document.createElement("img");
                img.src = uri;
                document.getElementById("deviceready").appendChild(img);
            };
            navigator.camera.getPicture(photoSuccess, fail, {
                        destinationType: navigator.camera.DestinationType.FILE_URI,
                        sourceType: navigator.camera.PictureSourceType.CAMERA,
                        saveToPhotoAlbum: false
                        });
            });
```

### Checklist
- [X] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

