### PR TITLE
CB-11644: (ios) Set cdvtoken cookie path to root

### DIFF
--- a/local-webserver/src/ios/CDVLocalWebServer.m
+++ b/local-webserver/src/ios/CDVLocalWebServer.m
@@ -239,7 +239,7 @@
 
             if (hasToken && !hasCookie) {
                 //set cookie
-                [response setValue:authToken forAdditionalHeader:@"Set-Cookie"];
+                [response setValue:[NSString stringWithFormat:@"%@;path=/", authToken] forAdditionalHeader:@"Set-Cookie"];
             }
             complete(response);
         });


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Set the cdvToken cookie's path to root, so it applies to all requests including those outside of www folder.

### What testing has been done on this change?
Tested on iOS 8.4.1

### Checklist
- [X] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

